### PR TITLE
utilise rawgit.com pour servir jquery.ba-replacetext.min.js

### DIFF
--- a/site/assets/souligneur.js
+++ b/site/assets/souligneur.js
@@ -125,7 +125,7 @@ function finish($) {
   $("head").append($("<link>").attr({rel: 'stylesheet',type: 'text/css',
      href: base+'souligneur.css'}));
   $.ajaxSetup({async: false});
-  $.getScript("http://github.com/cowboy/jquery-replacetext/raw/master/jquery.ba-replacetext.min.js",
+  $.getScript("https://cdn.rawgit.com/cowboy/jquery-replacetext/227662ec/jquery.ba-replacetext.min.js",
   function() {finish2($)});
 }
 


### PR DESCRIPTION
Par défaut, Chrome active le strict MIME type checking et refuse de charger le script depuis 'http://github.com/cowboy/jquery-replacetext/raw/master/jquery.ba-replacetext.min.js?_=1484821272373'. En effet, github sert par défaut les fichiers en "raw" avec le type  MIME 'text/plain'.

J'ai utilisé le site http://rawgit.com pour générer une URL servant le fichier jquery.ba-replacetext.min.js avec le type MIME 'application/javascript'.